### PR TITLE
Update plotly_auth.py

### DIFF
--- a/dash_auth/plotly_auth.py
+++ b/dash_auth/plotly_auth.py
@@ -13,8 +13,14 @@ import requests
 from hmac import compare_digest
 from six import iteritems
 
-import dash_html_components as html
-import dash_core_components as dcc
+from distutils.version import LooseVersion
+from dash import __version__ as dash_version
+if LooseVersion(dash_version) >= LooseVersion("2"):
+    from dash import html, dcc
+else:
+    import dash_html_components as html
+    import dash_core_components as dcc
+
 from dash.dependencies import Output, Input
 
 from .oauth import OAuthBase, need_request_context


### PR DESCRIPTION
Using with dash v2, dash_auth throws 2 UserWarnings because of the deprecation of dash_{html,dcc}_components.